### PR TITLE
Export classes so they can be used as types when importing into another typescript codebase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,11 @@
-import {Globals} from './globals';
-import {Utils} from './util';
-import {Ingredient} from './ingredient';
-import {Fermentable} from './fermentable';
-import {Spice} from './spice';
-import {Yeast} from './yeast';
-import {MashStep, MashStepType} from './mashStep';
-import {Mash} from './mash';
-import {Recipe} from './recipe';
-import {GuidService} from './guidService';
-import {BeerXml} from './beerxml';
-
-export = {
-    Globals, 
-    Utils,
-    Ingredient,
-    Fermentable,
-    Spice,
-    Yeast,
-    Mash,
-    MashStep,
-    MashStepType,
-    Recipe,
-    GuidService,
-    BeerXml
-};
+export {Globals} from './globals';
+export {Utils} from './util';
+export {Ingredient} from './ingredient';
+export {Fermentable} from './fermentable';
+export {Spice} from './spice';
+export {Yeast} from './yeast';
+export {MashStep, MashStepType} from './mashStep';
+export {Mash} from './mash';
+export {Recipe} from './recipe';
+export {GuidService} from './guidService';
+export {BeerXml} from './beerxml';


### PR DESCRIPTION
When importing brauhaus-ts as a named import in another typescript project, I was unable to use the brauhaus-ts classes as types.
This PR fixes that issue in the case of named imports, but I'm unsure as to the impact on other usages.
